### PR TITLE
chore(deploy): add splunk cloud env variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function readFileSecret(secret_file) {
 async function deployToEcs(deploy_file, version) {
   try {
     process.env.SPLUNK_TOKEN = readFileSecret('./SECRET_SPLUNK_TOKEN.txt');
+    process.env.SPLUNK_CLOUD_TOKEN = readFileSecret('./SECRET_SPLUNK_CLOUD_TOKEN.txt');
     process.env.NEW_RELIC_EVENT_INSERT_KEY = readFileSecret('./SECRET_NEW_RELIC_EVENT_INSERT_KEY.txt');
     process.env.NEW_RELIC_LICENSE_KEY = readFileSecret('./SECRET_NEW_RELIC_LICENSE_KEY.txt');
     process.env.NODE_AUTH_TOKEN = readFileSecret('./SECRET_NPM_TOKEN.txt');


### PR DESCRIPTION
Adding the splunk cloud token as process environment variable in the deploy step.﻿
